### PR TITLE
feat(build): add tagName (rn version) to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,3 +64,4 @@ jobs:
             --projectId ${{ inputs.projectId }} \
             --test ./e2e/${{ inputs.scenario }}_start.yaml \
             --testName ${{ inputs.scenario }}
+            --tagName ${{ inputs.rn_version }}


### PR DESCRIPTION
Adds tagName to the build in order to make it appear in the timeserie of RN versions' perf