### PR TITLE
fix: add new_arch param to test name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,5 +63,5 @@ jobs:
             --duration 10000 \
             --projectId ${{ inputs.projectId }} \
             --test ./e2e/${{ inputs.scenario }}_start.yaml \
-            --testName ${{ inputs.scenario }} \
+            --testName "${{ inputs.scenario }} - ${{ inputs.new_arch == true && 'New arch' || 'Old arch' }}" \
             --tagName ${{ inputs.rn_version }}


### PR DESCRIPTION
previously the test name was only the scenario, which caused it not to be selected in the graph display in the frontend. 