### PR TITLE
fix: adapt fetch-history return type to paging feature

### DIFF
--- a/.github/workflows/daily_build.yaml
+++ b/.github/workflows/daily_build.yaml
@@ -1,4 +1,4 @@
-name: Daily Build
+name: Build for untested RN versions
 
 on:
   workflow_dispatch:

--- a/dailyBuild/fetchVersionsHistory.ts
+++ b/dailyBuild/fetchVersionsHistory.ts
@@ -16,7 +16,7 @@ const fetchHistory = async (): Promise<HistoryResult> => {
 };
 
 const adaptHistoryToVersions = (history: HistoryResult): string[] => {
-  return history[0].result.data
+  return history[0].result.data.testRuns
     .sort(
       (a, b) => new Date(a.tag.date).getTime() - new Date(b.tag.date).getTime()
     )

--- a/dailyBuild/types.ts
+++ b/dailyBuild/types.ts
@@ -28,7 +28,7 @@ type TestRunResult = {
 export type HistoryResult = [
   {
     result: {
-      data: TestRunResult[];
+      data: { totalCount: number; testRuns: TestRunResult[] };
     };
   }
 ];


### PR DESCRIPTION
The return type of the test history was changed when adding paging to test fetch. This PR adapts the script that analyses RN nightly builds