### PR TITLE
chore(build rn app): enable hermes for all versions

### DIFF
--- a/setup-react-native-app.sh
+++ b/setup-react-native-app.sh
@@ -26,6 +26,7 @@ yarn
 sed -i -e "s/newArchEnabled=false/newArchEnabled=$ENABLE_NEW_ARCH/g" android/gradle.properties
 
 rm -f "react-native.config.js"
+sed -i -e "s/enableHermes: false/enableHermes: true/" android/app/build.gradle
 
 cd android
 


### PR DESCRIPTION
This PR enables Hermes for all versions, including pre-0.69