### PR TITLE
Fix/use adequate cli version when building

### DIFF
--- a/setup-react-native-app.sh
+++ b/setup-react-native-app.sh
@@ -25,6 +25,9 @@ yarn
 
 sed -i -e "s/newArchEnabled=false/newArchEnabled=$ENABLE_NEW_ARCH/g" android/gradle.properties
 
+sed -i -e "s/enableHermes: false/enableHermes: true/" android/app/build.gradle
+
+
 cd android
 ./gradlew assembleRelease
 mv app/build/outputs/apk/release/app-release.apk ../../../apks/$NAME-newarch_$ENABLE_NEW_ARCH-$SCENARIO.apk

--- a/setup-react-native-app.sh
+++ b/setup-react-native-app.sh
@@ -8,6 +8,10 @@ SCENARIO=$3
 release_name=${VERSION//./_}
 release_name=${release_name//-/_}
 release_name=$(echo "$release_name" | tr '[:lower:]' '[:upper:]')
+RN_CLI_VERSION=$(echo -e "0.73\n$VERSION" | sort -V | head -n1)
+if [ "$RN_CLI_VERSION" != "0.73" ]; then
+    RN_CLI_VERSION="0.72"
+fi
 
 NAME="RN$release_name"
 APP_FOLDER="$NAME"_"$ENABLE_NEW_ARCH"
@@ -15,7 +19,7 @@ APP_FOLDER="$NAME"_"$ENABLE_NEW_ARCH"
 mkdir -p apps
 mkdir -p apks
 cd apps
-npx react-native@$VERSION init $APP_FOLDER --version $VERSION
+npx react-native@$RN_CLI_VERSION init $APP_FOLDER --version $VERSION
 
 cp -R ../scenarios/$SCENARIO $APP_FOLDER/scenario
 cd $APP_FOLDER


### PR DESCRIPTION
A lot of builds fail due to the change in React native CLI in 0.73. The aim of this PR is to use the correct version of RN cli when starting an app.

<img width="675" alt="image" src="https://github.com/Almouro/react-native-flashlight-tests/assets/137884825/df49bce6-c775-4202-9d34-3098c8941282">
