### PR TITLE
chore: update testName after migration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,5 +63,5 @@ jobs:
             --duration 10000 \
             --projectId ${{ inputs.projectId }} \
             --test ./e2e/${{ inputs.scenario }}_start.yaml \
-            --testName "${{ inputs.scenario }} - ${{ inputs.new_arch == true && 'New arch' || 'Old arch' }}" \
+            --testName "${{ inputs.scenario }}_${{ inputs.new_arch == true && 'New-arch' || 'Old-arch' }}" \
             --tagName ${{ inputs.rn_version }}


### PR DESCRIPTION
This PR removes the spaces from the testNames registered by the "build" job