### PR TITLE
fix(hotfix ninghtly builds): remove all 73 nightly builds from computation

### DIFF
--- a/dailyBuild/computeMissingVersions.ts
+++ b/dailyBuild/computeMissingVersions.ts
@@ -14,9 +14,9 @@ export const computeMissingVersions = async (
     );
   }
 
-  const availableVersions = allVersions.slice(
-    allVersions.indexOf(startVersion)
-  );
+  const availableVersions = allVersions
+    .slice(allVersions.indexOf(startVersion))
+    .filter((version) => !version.includes("0.73.0-nightly")); // remove 0.73.0-nightly versions since they fail systematically
 
   const missingVersions: string[] = [];
 


### PR DESCRIPTION
As these builds systematically fail, I remove them until we find a solution to make these builds work (or stop fetching failed builds), so that the bot stops registering 15 new versions every night