### PR TITLE
fix(build): remove RN config when it exists

### DIFF
--- a/setup-react-native-app.sh
+++ b/setup-react-native-app.sh
@@ -25,8 +25,12 @@ yarn
 
 sed -i -e "s/newArchEnabled=false/newArchEnabled=$ENABLE_NEW_ARCH/g" android/gradle.properties
 
+rm -f "react-native.config.js"
+
 cd android
-./gradlew assembleRelease
+
+./gradlew clean assembleRelease
+
 mv app/build/outputs/apk/release/app-release.apk ../../../apks/$NAME-newarch_$ENABLE_NEW_ARCH-$SCENARIO.apk
 
 echo "APK_PATH=apks/$NAME-newarch_$ENABLE_NEW_ARCH-$SCENARIO.apk" >> $GITHUB_ENV


### PR DESCRIPTION
For some RN versions, a config file is created with the option "automaticPodInstall" set to true. This breaks the build due to lacking permissions. 